### PR TITLE
fix: update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,15 @@ Mesa-Replay is developed with the goal of being **simple**, **generic** and **ac
 # Installation
 
 To locally install Mesa-Replay as a pip module, use
-> pip -e install .
+> pip install -e .
 
 
 # How to Use
 
 For usage examples, see [here](https://github.com/Logende/mesa-replay/tree/main/examples).
 
-The [test files](https://github.com/Logende/mesa-replay/tree/main/tests) (they have extensive descriptions) also illustrate the functionality of Mesa-Replay.
+The [test files](https://github.com/Logende/mesa-replay/tree/main/tests) (they have extensive descriptions) also illustrate the functionality of Mesa-Replay. To test them, run:
+
+```bash
+python -m unittest tests/test_*
+```

--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ Mesa-Replay is developed with the goal of being **simple**, **generic** and **ac
 
 # Installation
 
-To locally install Mesa-Replay as a pip module, use
-> pip install -e .
-
+To locally install Mesa-Replay as a pip module, install in ['editable' mode](https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs):
+```bash
+pip install -e .
+```
 
 # How to Use
 


### PR DESCRIPTION
fixed a typo in the install instructions using `pip`, and also include a command on how to run the tests.